### PR TITLE
Updated pivot_wider to include values_fill option

### DIFF
--- a/tests/test_tidypolars.py
+++ b/tests/test_tidypolars.py
@@ -117,6 +117,13 @@ def tets_pivot_wider2():
     expected = tp.Tibble({'id': [1], 'x': [1], 'y': [2], 'z': [3]})
     assert actual.frame_equal(expected), "pivot_wider with id failed"
 
+def tets_pivot_wider3():
+    """Can pivot cols to wide with values filled"""
+    df = tp.Tibble({'id': _repeat(1, 3), 'label': ['x', 'y', 'z'], 'val': range(1, 4)})
+    actual = df.pivot_wider(names_from = 'label', values_from = 'id', values_fill= 0)
+    expected = tp.Tibble({'val': [1,2,3], 'y': [0,0,1], 'x': [1,0,0], 'z': [0,1,0]})
+    assert actual.frame_equal(expected), "pivot_wider with values filled failed"
+
 def test_pull():
     """Can use pull"""
     df = tp.Tibble({'x': _repeat(1, 3), 'y': _repeat(2, 3)})

--- a/tidypolars/tidypolars.py
+++ b/tidypolars/tidypolars.py
@@ -267,7 +267,8 @@ class Tibble(pl.DataFrame):
                     names_from: str = 'name',
                     values_from: str = 'value',
                     id_cols: Union[str, List[str]] = None,
-                    values_fn: str = 'first'):
+                    values_fn: str = 'first', 
+                    values_fill: str = None):
         """
         Pivot data from long to wide
 
@@ -283,6 +284,9 @@ class Tibble(pl.DataFrame):
             `names_from` and `values_from`.
         values_fn : str
             Function for how multiple entries per group should be dealt with.
+        values_fill : str
+            If values are missing/null, what value should be filled in.
+            Can use: "backward", "forward", "mean", "min", "max", "zero", "one" or an expression
 
         Examples
         --------
@@ -307,7 +311,7 @@ class Tibble(pl.DataFrame):
 
         values_fn = fn_options[values_fn]
 
-        out = values_fn(self.groupby(id_cols).pivot(names_from, values_from))
+        out = values_fn(self.groupby(id_cols).pivot(names_from, values_from)).fill_null(values_fill)
 
         return out.pipe(from_polars)
 


### PR DESCRIPTION
Can you also take a look at the tests for pivot_wider? I tried to rename **tets_pivot_wider** but it threw a bunch of errors whenever I ran pytests. 